### PR TITLE
feat: QueryDSL 및 JPA 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.4'
@@ -10,12 +16,6 @@ version = '0.0.1-SNAPSHOT'
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
-    }
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
     }
 }
 
@@ -35,10 +35,33 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'mysql:mysql-connector-java:8.0.33'
+
+    // QueryDSL dependencies
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/org/data/nowgnas/config/jpa/JpaConfiguration.java
+++ b/src/main/java/org/data/nowgnas/config/jpa/JpaConfiguration.java
@@ -1,0 +1,10 @@
+package org.data.nowgnas.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaAuditing
+@EnableJpaRepositories(basePackages = "org.data.nowgnas.**.jpa")
+public class JpaConfiguration {}

--- a/src/main/java/org/data/nowgnas/config/querydsl/QuerydslConfiguration.java
+++ b/src/main/java/org/data/nowgnas/config/querydsl/QuerydslConfiguration.java
@@ -1,0 +1,17 @@
+package org.data.nowgnas.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfiguration {
+  @PersistenceContext private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/org/data/nowgnas/domain/process/dao/entity/DataProcessingEntity.java
+++ b/src/main/java/org/data/nowgnas/domain/process/dao/entity/DataProcessingEntity.java
@@ -1,0 +1,26 @@
+package org.data.nowgnas.domain.process.dao.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "data_process")
+public class DataProcessingEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String data;
+}

--- a/src/main/java/org/data/nowgnas/domain/process/dao/jpa/DataProcessingJpaRepository.java
+++ b/src/main/java/org/data/nowgnas/domain/process/dao/jpa/DataProcessingJpaRepository.java
@@ -1,0 +1,6 @@
+package org.data.nowgnas.domain.process.dao.jpa;
+
+import org.data.nowgnas.domain.process.dao.entity.DataProcessingEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DataProcessingJpaRepository extends JpaRepository<DataProcessingEntity, Long> {}

--- a/src/main/java/org/data/nowgnas/domain/process/service/DataProcessService.java
+++ b/src/main/java/org/data/nowgnas/domain/process/service/DataProcessService.java
@@ -1,0 +1,29 @@
+package org.data.nowgnas.domain.process.service;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.data.nowgnas.domain.process.dao.entity.DataProcessingEntity;
+import org.data.nowgnas.domain.process.dao.entity.QDataProcessingEntity;
+import org.data.nowgnas.domain.process.dao.jpa.DataProcessingJpaRepository;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DataProcessService {
+  private final DataProcessingJpaRepository dataProcessingJpaRepository;
+  private final JPAQueryFactory queryFactory;
+
+  public DataProcessingEntity selectById(Long id) {
+    return dataProcessingJpaRepository.findById(id).orElse(null);
+  }
+
+  public DataProcessingEntity selectByIdWithQueryDsl(Long id) {
+    QDataProcessingEntity dataProcessingEntity = QDataProcessingEntity.dataProcessingEntity;
+    return queryFactory
+        .selectFrom(dataProcessingEntity)
+        .where(dataProcessingEntity.id.eq(id))
+        .fetchOne();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,17 @@
 spring:
   kafka:
     bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+  datasource:
+    url: jdbc:mysql://localhost:3306/develop?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8
+    username: root
+    password: 123456
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Spring Boot 3.x 환경에 맞춰 QueryDSL과 JPA 설정을 추가하고 관련 문제를 해결합니다.

- Spring Boot 3.x(Jakarta EE)에 맞는 QueryDSL 의존성 및 빌드 설정 추가
- `javax.persistence`를 `jakarta.persistence`로 마이그레이션
- 테스트 환경에서 H2 인메모리 데이터베이스를 사용하도록 설정하여 DB 연결 문제 해결
- `DataProcessingEntity` 및 관련 서비스 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database integration with MySQL for main environments and H2 for testing, including configuration for connection pooling and JPA settings.
  * Introduced a new data processing entity and repository, enabling CRUD operations on data processing records.
  * Implemented a service with methods to retrieve data processing records by ID using both standard and QueryDSL-based queries.
  * Enabled JPA auditing and repository scanning for streamlined data management.
  * Provided QueryDSL integration for type-safe database queries.

* **Chores**
  * Added and updated configuration files for database and Kafka integration in both main and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->